### PR TITLE
fix(Nix): start home-manager service after Hyprland

### DIFF
--- a/nix/hm.nix
+++ b/nix/hm.nix
@@ -66,12 +66,12 @@ in {
     home.packages = [cfg.package];
 
     systemd.user.services.hyprscratch = {
-      Install = {
-        WantedBy = ["default.target"];
-      };
+      Install.WantedBy = ["hyprland-session.target"];
 
       Unit = {
         Description = "Hyprscratch: Improved scratchpad functionality for Hyprland";
+        PartOf = ["hyprland-session.target"];
+        After = ["hyprland-session.target"];
       };
 
       Service = {


### PR DESCRIPTION
This ensures the Hyprscratch service is started after Hyprland.
Otherwise, it would not be able to find the Hyprland socket and have to be manually restarted.