### PR TITLE
feat: reapply rules when showing or refocusing scratchpads

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -144,9 +144,10 @@ impl ParserState {
     }
 
     fn create_scratchpad(&mut self) -> Scratchpad {
+        let rules_str = self.scratchpad_data["rules"].replace(',', ";");
         let command = &prepend_rules(
             &self.scratchpad_data["command"],
-            &self.scratchpad_data["rules"].replace(',', ";"),
+            &rules_str,
         )
         .join("?");
 
@@ -157,7 +158,9 @@ impl ParserState {
         };
 
         let options = &self.scratchpad_data["options"];
-        Scratchpad::new(title, command, options)
+        let mut sc = Scratchpad::new(title, command, options);
+        sc.rules = rules_str;
+        sc
     }
 
     fn append_to_field(&mut self, k: &str, v: &str) {

--- a/src/scratchpad.rs
+++ b/src/scratchpad.rs
@@ -132,6 +132,7 @@ enum TriggerMode<T> {
 pub struct Scratchpad {
     pub title: String,
     pub command: String,
+    pub rules: String,
     pub options: ScratchpadOptions,
 }
 
@@ -140,12 +141,22 @@ impl Scratchpad {
         Scratchpad {
             title: title.into(),
             command: command.into(),
+            rules: String::new(),
             options: ScratchpadOptions::new(options),
         }
     }
 
     pub fn add_rules(&mut self, rules: &str) {
         self.command = prepend_rules(&self.command, rules).join("?");
+        if !rules.is_empty() {
+            if !self.rules.is_empty() {
+                // Prepend new rules before existing ones so per-scratchpad rules
+                // (set earlier) take precedence over global rules (added later)
+                self.rules = format!("{};{}", rules, self.rules);
+            } else {
+                self.rules = rules.to_string();
+            }
+        }
     }
 
     pub fn add_opts(&mut self, options: &str) {
@@ -235,6 +246,8 @@ impl Scratchpad {
     }
 
     fn show_normal(&self, state: &HyprlandState) -> Result<()> {
+        let mut shown = false;
+
         for client in state
             .clients_with_title
             .iter()
@@ -258,8 +271,32 @@ impl Scratchpad {
                 )?;
             }
 
+            reapply_rules(client, &self.rules, !self.options.tiled);
+            shown = true;
+
             if !self.options.poly {
                 break;
+            }
+        }
+
+        // If no clients were moved (all already on workspace), reapply rules
+        // to clients already here. This handles apps like Spotify whose windows
+        // ignore exec rules at spawn and end up tiled.
+        if !shown {
+            for client in state
+                .clients_with_title
+                .iter()
+                .filter(|cl| self.is_on_workspace(cl, state))
+            {
+                hyprland::dispatch!(
+                    FocusWindow,
+                    WindowIdentifier::Address(client.address.clone())
+                )?;
+                reapply_rules(client, &self.rules, !self.options.tiled);
+
+                if !self.options.poly {
+                    break;
+                }
             }
         }
 
@@ -338,11 +375,12 @@ impl Scratchpad {
         }
     }
 
-    fn refocus(client: &Client) -> Result<()> {
+    fn refocus(&self, client: &Client) -> Result<()> {
         hyprland::dispatch!(
             FocusWindow,
             WindowIdentifier::Address(client.address.clone())
         )?;
+        reapply_rules(client, &self.rules, !self.options.tiled);
         Ok(())
     }
 
@@ -355,7 +393,7 @@ impl Scratchpad {
     pub fn trigger(&self, title_map: &HashMap<String, String>, name: &str) -> Result<()> {
         let state = HyprlandState::new(&self.title, name)?;
         match self.get_mode(&state) {
-            Refocus(client) => Self::refocus(client)?,
+            Refocus(client) => self.refocus(client)?,
             Hide(clients) => self.hide(clients, &state),
             Summon => self.summon(&state)?,
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,8 +2,8 @@ use crate::config::Config;
 use crate::scratchpad::Scratchpad;
 use crate::DEFAULT_SOCKET;
 use crate::{logs::*, KNOWN_CLI_COMMANDS};
-use hyprland::data::{Client, Clients};
-use hyprland::dispatch::{WindowIdentifier, WorkspaceIdentifierWithSpecial};
+use hyprland::data::{Client, Clients, Monitors};
+use hyprland::dispatch::*;
 use hyprland::prelude::*;
 use hyprland::Result;
 use std::collections::HashMap;
@@ -217,6 +217,142 @@ pub fn autospawn(config: &mut Config) -> Result<()> {
         .for_each(spawn);
 
     Ok(())
+}
+
+/// Evaluate a size/position expression like "monitor_w*0.95", "30%", "800"
+fn eval_expr(expr: &str, monitor_w: f64, monitor_h: f64, is_width: bool) -> Option<i64> {
+    let expr = expr.trim();
+    if expr.is_empty() {
+        return None;
+    }
+
+    // Percentage: "30%"
+    if let Some(pct) = expr.strip_suffix('%') {
+        let p = pct.trim().parse::<f64>().ok()?;
+        let base = if is_width { monitor_w } else { monitor_h };
+        return Some((base * p / 100.0) as i64);
+    }
+
+    // Expression with monitor variables: "monitor_w*0.95"
+    if expr.contains("monitor_w") || expr.contains("monitor_h") {
+        let replaced = expr
+            .replace("monitor_w", &monitor_w.to_string())
+            .replace("monitor_h", &monitor_h.to_string());
+
+        // Handle multiplication: "2560*0.95"
+        if let Some((a, b)) = replaced.split_once('*') {
+            let a = a.trim().parse::<f64>().ok()?;
+            // Handle subtraction after multiplication: "2560*0.95-60"
+            if let Some((mul, sub)) = b.trim().split_once('-') {
+                let mul = mul.trim().parse::<f64>().ok()?;
+                let sub = sub.trim().parse::<f64>().ok()?;
+                return Some((a * mul - sub) as i64);
+            }
+            let b = b.trim().parse::<f64>().ok()?;
+            return Some((a * b) as i64);
+        }
+
+        // Just a variable reference: "monitor_w"
+        return replaced.trim().parse::<f64>().ok().map(|v| v as i64);
+    }
+
+    // Plain number
+    expr.parse::<f64>().ok().map(|v| v as i64)
+}
+
+/// Reapply scratchpad rules (size, position, float) to an existing window.
+/// Called after showing or refocusing a scratchpad so rules are enforced
+/// even if the window was previously resized or moved.
+pub fn reapply_rules(client: &Client, rules: &str, should_float: bool) {
+    let (monitor_w, monitor_h) = match get_focused_monitor_dimensions() {
+        Some(dims) => dims,
+        None => return,
+    };
+
+    let addr = client.address.clone();
+
+    // Ensure floating if the scratchpad isn't configured as tiled
+    if should_float && !client.floating {
+        Dispatch::call(DispatchType::ToggleFloating(Some(
+            WindowIdentifier::Address(addr.clone()),
+        )))
+        .log_err(file!(), line!());
+    }
+
+    if rules.is_empty() {
+        return;
+    }
+
+    // Parse rules to find the final size/position state.
+    // Later rules override earlier ones (per-scratchpad overrides global).
+    let mut final_size: Option<(i64, i64)> = None;
+    let mut final_center = false;
+    let mut final_move: Option<(i64, i64)> = None;
+
+    for rule in rules.split(';') {
+        let rule = rule.trim();
+        if rule.is_empty() {
+            continue;
+        }
+
+        if rule == "float" {
+            // Already handled above
+        } else if let Some(size_args) = rule.strip_prefix("size ") {
+            let parts: Vec<&str> = size_args.trim().splitn(2, char::is_whitespace).collect();
+            if parts.len() == 2 {
+                if let (Some(w), Some(h)) = (
+                    eval_expr(parts[0], monitor_w, monitor_h, true),
+                    eval_expr(parts[1], monitor_w, monitor_h, false),
+                ) {
+                    final_size = Some((w, h));
+                    // New size invalidates previous center/move
+                    final_center = false;
+                    final_move = None;
+                }
+            }
+        } else if let Some(move_args) = rule.strip_prefix("move ") {
+            let parts: Vec<&str> = move_args.trim().splitn(2, char::is_whitespace).collect();
+            if parts.len() == 2 {
+                if let (Some(x), Some(y)) = (
+                    eval_expr(parts[0], monitor_w, monitor_h, true),
+                    eval_expr(parts[1], monitor_w, monitor_h, false),
+                ) {
+                    final_move = Some((x, y));
+                    final_center = false;
+                }
+            }
+        } else if rule == "center" {
+            final_center = true;
+            final_move = None;
+        }
+    }
+
+    // Apply the final computed state
+    if let Some((w, h)) = final_size {
+        Dispatch::call(DispatchType::Custom(
+            "resizewindowpixel",
+            &format!("exact {} {},address:{}", w, h, addr),
+        ))
+        .log_err(file!(), line!());
+    }
+
+    if let Some((x, y)) = final_move {
+        Dispatch::call(DispatchType::Custom(
+            "movewindowpixel",
+            &format!("exact {} {},address:{}", x, y, addr),
+        ))
+        .log_err(file!(), line!());
+    } else if final_center {
+        // centerwindow operates on the focused window (no address targeting)
+        Dispatch::call(DispatchType::Custom("centerwindow", "1"))
+            .log_err(file!(), line!());
+    }
+}
+
+fn get_focused_monitor_dimensions() -> Option<(f64, f64)> {
+    let monitors = Monitors::get().ok()?;
+    let monitor = monitors.into_iter().find(|m| m.focused)?;
+    Some((monitor.width as f64, monitor.height as f64))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Store raw rules string separately in `Scratchpad` struct alongside the baked-in exec command
- After showing (`show_normal`) or refocusing (`refocus`) an existing scratchpad, reapply rules via `resizewindowpixel`, `movewindowpixel`, `centerwindow`, and `togglefloating` dispatches
- Evaluate `monitor_w`/`monitor_h` expressions, percentages, and plain pixel values against the focused monitor's dimensions
- Handle windows already on the active workspace that ended up tiled because they ignored initial exec float rules (e.g. Spotify)

## Motivation

Scratchpad rules (size, move, center, float) were only applied at spawn time via Hyprland exec rules. This caused two problems:

1. If a user manually resized or moved a scratchpad, hiding and re-showing it would not reset to the configured state
2. Apps like Spotify that create their window asynchronously would ignore exec rules entirely, spawning tiled at the wrong size

This was requested in #14.

## Test plan

- [x] Scratchpad with `size monitor_w*0.95 monitor_h*0.95;center` rules: manually resize, toggle hide/show, verify size and centering restored
- [x] Spotify (ignores exec rules at spawn): toggle once, verify it becomes floating at configured size
- [x] Dropdown terminal with custom `move`/`size` rules: verify per-scratchpad rules override global rules correctly
- [x] Build passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)